### PR TITLE
Fix endless simulation bug: non-rigid robots stuck on sub-tick WAIT

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -299,7 +299,8 @@ class Robot:
         # underflow / rounding) -> elapsed_time == 0 strands the robot at its start,
         # which then re-LOOKs forever (the endless-simulation bug).
         if (self.state == RobotState.MOVE and self.start_time is not None
-                and self.calculated_position is not None and self.rigid_movement):
+                and self.calculated_position is not None
+                and (self.rigid_movement or time <= self.start_time + 1e-12)):
             final_pos = self.calculated_position
         else:
             final_pos = self.get_position(time)


### PR DESCRIPTION
## Root Cause

When  (sub-tick case, issue #1), a non-rigid robot's `wait()` call uses `get_position(time)` which computes `elapsed = time - start_time ≈ 0` and returns `self.coordinates` (unchanged). The robot never advances position, so the next LOOK computes the same target → sub-tick again → **infinite loop** / livelock.

The snap-to-`calculated_position` logic already existed for `rigid_movement=True` but was guarded behind that flag.

## Fix

Extend the snap condition in `robot.py:wait()` to also trigger when `time <= self.start_time + 1e-12` (sub-tick / effectively zero elapsed), regardless of the `rigid_movement` setting. This is safe because a WAIT event scheduled at (nearly) the same instant as the MOVE event is always meant to arrive at the computed target.

## Change

```diff
 if (self.state == RobotState.MOVE and self.start_time is not None
         and self.calculated_position is not None
-        and self.rigid_movement):
+        and (self.rigid_movement or time <= self.start_time + 1e-12)):
     final_pos = self.calculated_position
 else:
     final_pos = self.get_position(time)
```

Closes #1